### PR TITLE
Timestamp fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Introduction
 ------------
 
 This library consists mainly of code that arose out of my curiosity, either
-about Erlang and coding in general or concerning a pericular protocol or
+about Erlang and coding in general or concerning a perticular protocol or
 technique. So there is little of cohesion in purposes between the different
 library modules. But having published these I will continue to support these
 since the road to enlightenment is one without terminus.

--- a/src/jhn_stdlib.app.src
+++ b/src/jhn_stdlib.app.src
@@ -26,7 +26,7 @@
 %%%-------------------------------------------------------------------
 {application, jhn_stdlib,
  [{description, "Jan Henry Nystrom's standard library"},
-  {vsn, "3.9.1"},
+  {vsn, "3.9.2"},
   {registered, []},
   {applications, [kernel, stdlib]},
   {env, []},

--- a/src/timestamp.erl
+++ b/src/timestamp.erl
@@ -116,9 +116,9 @@ gen() -> gen([]).
 -spec gen([opt()] | #opts{}) -> list()| iolist() | binary() | posix().
 %%--------------------------------------------------------------------
 gen(#opts{precision = Precision, return_type = posix}) ->
-    os:system_time(precision(Precision));
+    erlang:system_time(precision(Precision));
 gen(Opts = #opts{precision = Precision}) ->
-    encode(os:system_time(precision(Precision)), Opts);
+    encode(erlang:system_time(precision(Precision)), Opts);
 gen(Opts) ->
     gen(parse_opts(Opts, #opts{})).
 


### PR DESCRIPTION
When using the os:system_time/1 version nano seconds alternatives does not work properly.