### PR TITLE
Added non dash uuids.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Features/Modules
     * ```jhn_mustache``` -- [Mustache (template system)][37]
   * Protocols
     * Bencoding -- encoding/decoding -- ```jhn_bencoding```
-    * CBOR -- encoding/decoding -- ```jhn_cbor``` [rfc8949][43], [rfc9542][44]
+    * CBOR -- encoding/decoding -- ```jhn_cbor``` [rfc8949][43], [rfc9542][45]
     * JSON  -- encoding/decoding -- ```jhn_json``` [rfc8259][30]
     * JSON Pointer -- encoding/decoding/evaluation -- ```jhn_json``` [rfc6901][8]
     * JSON Patch -- evaluation -- ```jhn_json``` [rfc6902][31]
@@ -52,7 +52,7 @@ Features/Modules
     * IP Addresses -- encoding/decoding -- ```jhn_ip_addr``` [rfc4291][16], [rfc5952][17], [rfc4632][18]
     * Timestamps -- generating/encoding/decoding -- ```jhn_timestamp``` [rfc3339][19], [rfc7231][21]
     * URI -- encoding/decoding -- ```jhn_uri``` [rfc3986][15]
-    * UUID -- generating/encoding/decoding -- ```jhn_uuid``` [rfc9562][42]
+    * UUID -- generating/encoding/decoding -- ```jhn_uuid``` [rfc9562][42][rfc8144]
   * Clients
     * HTTP -- client -- ```jhn_shttpc``` [rfc7230][20], [rfc7231][21], [rfc7538][22], [rfc5789][23], [rfc2818][24]
     * Syslog -- server/client -- ```jhn_syslog``` [rfc5425][25], [rfc5426][26], [rfc6587][27]
@@ -163,3 +163,4 @@ I know I really should.
   [42]: http://www.ietf.org/rfc/rfc9562.txt "Universally Unique IDentifiers (UUIDs)"
   [43]: http://www.ietf.org/rfc/rfc8949.txt "Concise Binary Object Representation (CBOR)"
   [44]: http://www.ietf.org/rfc/rfc9542.txt "IANA Considerations and IETF Protocol and Documentation Usage for IEEE 802 Parameters"
+  [45]: http://www.ietf.org/rfc/rfc8141.txt "Uniform Resource Names (URNs)"

--- a/test/jhn_uuid_tests.erl
+++ b/test/jhn_uuid_tests.erl
@@ -57,10 +57,14 @@ gen_2_test_() ->
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v1, [list])))},
      {"gen(v1, [list, urn])",
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v1, [list, urn])))},
+     {"gen(v1, [list, hex])",
+      ?_test(?assertMatch([_ | _], jhn_uuid:gen(v1, [list, hex])))},
      {"gen(v4, [list])",
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v4, [list])))},
-     {"gen(v4, [list])",
+     {"gen(v4, [list, urn])",
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v4, [list, urn])))},
+     {"gen(v4, [list, hex])",
+      ?_test(?assertMatch([_ | _], jhn_uuid:gen(v4, [list, hex])))},
      {"gen(v6, [list])",
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v6, [list])))},
      {"gen(v6, [list])",
@@ -90,6 +94,8 @@ gen_2_test_() ->
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v6, [iolist])))},
      {"gen(v6, [iolist, urn])",
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v6, [iolist, urn])))},
+     {"gen(v6, [iolist, hex])",
+      ?_test(?assertMatch([_ | _], jhn_uuid:gen(v6, [iolist, hex])))},
      {"gen(v7, [iolist])",
       ?_test(?assertMatch([_ | _], jhn_uuid:gen(v7, [iolist])))},
      {"gen(v7, [iolist, urn])",
@@ -119,6 +125,8 @@ gen_2_test_() ->
       ?_test(?assertMatch(<<_/binary>>, jhn_uuid:gen(v7, [binary])))},
      {"gen(v7, [binary, urn])",
       ?_test(?assertMatch(<<_/binary>>, jhn_uuid:gen(v7, [binary, urn])))},
+     {"gen(v7, [binary, hex])",
+      ?_test(?assertMatch(<<_/binary>>, jhn_uuid:gen(v7, [binary, hex])))},
      {"gen(nil, [binary])",
       ?_test(?assertMatch(<<_/binary>>, jhn_uuid:gen(nil, [binary])))},
      {"gen(nil, [binary, urn])",
@@ -315,8 +323,9 @@ gen_2_test_() ->
                           jhn_uuid:gen(v8, [{custom, custom(integer)}])))},
      {"gen(v8, [{custom, Binary}])",
       ?_test(?assertMatch([_ | _],
-                          jhn_uuid:gen(v8, [{custom, custom(binary)}])))}
-
+                          jhn_uuid:gen(v8, [{custom, custom(binary)}])))},
+     {"gen(v2, [binary])",
+      ?_test(?assertError(badarg, jhn_uuid:gen(v2, [binary])))}
     ].
 
 %%--------------------------------------------------------------------
@@ -366,7 +375,11 @@ decode_2_test_() ->
      {"decode(gen(v7, [binary], human)",
       ?_test(?assertMatch(#{version := 7},
                           jhn_uuid:decode(
-                            jhn_uuid:gen(v7, [binary]), [human])))}
+                            jhn_uuid:gen(v7, [binary]), [human])))},
+     {"decode(gen(v7, [binary, hex], human)",
+      ?_test(?assertMatch(#{version := 7},
+                          jhn_uuid:decode(
+                            jhn_uuid:gen(v7, [binary, hex]), [human])))}
     ].
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
The non-standard but used of format of UUIDs is one where the hex-int without dashes is used. Support is added for this both in decoding and generating with the option hex.

Also updated documentation.